### PR TITLE
Django v5.1.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,8 @@ requirements:
     - python
     - asgiref >=3.8.1,<4
     - sqlparse >=0.3.1
+    # the conda python package depends on tzdata
+    #- tzdata  # [win]
   run_constrained:
     - argon2-cffi >=19.1.0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.1" %}
+{% set version = "5.1.3" %}
 
 package:
   name: django
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/D/Django/Django-{{ version }}.tar.gz
-  sha256: 848a5980e8efb76eea70872fb0e4bc5e371619c70fffbe48e3e1b50b2c09455d
+  sha256: c0fa0e619c39325a169208caef234f90baa925227032ad3f44842ba14d75234a
 # python-tzdata is a fallback package for systems not providing timezone data, but the conda python package depends on tzdata.
 # Therefore we do not need to depend on python-tzdata.
   patches:
@@ -28,7 +28,7 @@ requirements:
     - wheel
   run:
     - python
-    - asgiref >=3.8.1
+    - asgiref >=3.8.1,<4
     - sqlparse >=0.3.1
   run_constrained:
     - argon2-cffi >=19.1.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,8 +30,6 @@ requirements:
     - python
     - asgiref >=3.8.1,<4
     - sqlparse >=0.3.1
-    # the conda python package depends on tzdata
-    #- tzdata  # [win]
   run_constrained:
     - argon2-cffi >=19.1.0
 


### PR DESCRIPTION
> ## ☆Django v5.1.3☆
> [Jira Ticket](https://anaconda.atlassian.net/browse/PKG-6005) 
[Upstream](https://github.com/django/django/tree/5.1.3)
> 
> ### Changes
> * Updated version number and sha256
> * Updated dependencies for `run` and `host` 
