### PR TITLE
django 5.2.8 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "django" %}
-{% set version = "5.2.7" %}
+{% set version = "5.2.8" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/{{ name }}/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 2b99994c8f9a31740cb9452aaf518f09ab9b446916bba80d1dcc31c1474b53fa
+  sha256: cb217ba7b0742bbff7b4c5911aad53458507ff668d03bc4de764f604ee21c0d7
   patches:
     - patches/001-Win-tzdata-removal.patch   # [win]
 # python-tzdata is a fallback package for systems not providing timezone data, but the conda python package depends on tzdata.


### PR DESCRIPTION
django 5.2.8 

**Destination channel:** Defaults

### Links

- [PKG-10983]
- dev_url:        https://github.com/django/django/tree/5.2.8
- conda_forge:    https://github.com/conda-forge/django-feedstock
- pypi:           https://pypi.org/project/django/5.2.8
- pypi inspector: https://inspector.pypi.io/project/django/5.2.8

### Explanation of changes:

- new version number


[PKG-10983]: https://anaconda.atlassian.net/browse/PKG-10983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ